### PR TITLE
Splice clips into a full highlight video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 demofile-parsing/package-lock.json
 demofile-parsing/node_modules/
 output.html
+timestamps.json
+highlights.mp4

--- a/demofile-parsing/Round.js
+++ b/demofile-parsing/Round.js
@@ -84,13 +84,15 @@ class Round {
   }
 
   getStreamTimestamps(demoGameStart, streamGameStart) {
-    var result = [];
+    var asTimestamps = [];
+    var asSeconds = []
     for (var i = 0; i < this.highlights.length; i++) {
-      var s = this.highlights[i][0] - demoGameStart + streamGameStart;
-      var e = this.highlights[i][1] - demoGameStart + streamGameStart;
-      result.push([this.secondsToTimestamp(s), this.secondsToTimestamp(e)]);
+      var s = Math.floor(this.highlights[i][0] - demoGameStart + streamGameStart);
+      var e = Math.floor(this.highlights[i][1] - demoGameStart + streamGameStart);
+      asSeconds.push([s, e]);
+      asTimestamps.push([this.secondsToTimestamp(s), this.secondsToTimestamp(e)]);
     }
-    return result;
+    return { timestamps: asTimestamps, timestampsAsSeconds: asSeconds };
   }
 
   secondsToTimestamp(seconds) {

--- a/demofile-parsing/index.js
+++ b/demofile-parsing/index.js
@@ -6,7 +6,7 @@ Logger.log(`Welcome to the Highlight Generator Tool`);
 
 if(TESTING){ 
     Logger.log('Parse Running...');
-    var parseDemo = require('./parse_demo.js');
+    const parseDemo = require('./parse_demo.js');
     parseDemo(TEST_URL, TEST_FILE_PATH, TEST_START_TIME);
 }
 else {

--- a/demofile-parsing/parse_demo.js
+++ b/demofile-parsing/parse_demo.js
@@ -40,7 +40,7 @@ const parseDemo = async (url, demPath, streamGameStart) => {
   const demoFile = new demofile.DemoFile();
   const outputPage = new ClipTemplate(getVideoId(url));
   const rounds = [];
-  const roundEvents = [];
+  var roundEvents = [];
   const allHighlights = [];
   var roundLatestStart = 0;
   var roundOn = false;

--- a/demofile-parsing/parse_demo.js
+++ b/demofile-parsing/parse_demo.js
@@ -104,7 +104,7 @@ const parseDemo = async (url, demPath, streamGameStart) => {
     }
     Logger.log("Demofile parsing complete.");
     Logger.debug(allHighlights);
-
+    // write highlights to json file after parsing is finished
     fs.writeFile("./timestamps.json", JSON.stringify(allHighlights), (err) => {
       if (err) {
           Logger.log(err);

--- a/demofile-parsing/parse_demo.js
+++ b/demofile-parsing/parse_demo.js
@@ -35,104 +35,123 @@ function getVideoId(url) {
   return videoId;
 }
 
-var parseDemo = function(url, demPath, streamGameStart){
-  fs.readFile(path.resolve(demPath), (err, buffer) => {
-    const demoFile = new demofile.DemoFile();
-    const outputPage = new ClipTemplate(getVideoId(url));
-    const rounds = [];
-    var roundEvents = [];
-    var roundLatestStart = 0;
-    var roundOn = false;
-    var roundIndex = 0;
-  
-    // parse start of the round
-    demoFile.gameEvents.on("round_start", e => {
-      roundOn = true;
-      roundEvents = [];
+const parseDemo = async (url, demPath, streamGameStart) => {
+  const buffer = fs.readFileSync(path.resolve(demPath));
+  const demoFile = new demofile.DemoFile();
+  const outputPage = new ClipTemplate(getVideoId(url));
+  const rounds = [];
+  const roundEvents = [];
+  const allHighlights = [];
+  var roundLatestStart = 0;
+  var roundOn = false;
+  var roundIndex = 0;
+
+  // parse start of the round
+  demoFile.gameEvents.on("round_start", e => {
+    roundOn = true;
+    roundEvents = [];
+    var t = demoFile.currentTime;
+    roundLatestStart = t;
+    // log round start
+    Logger.log(`round ${roundIndex} started ${secondsToTimestamp(t, demoGameStart, streamGameStart)}`);
+
+    Logger.debug(t);
+  });
+
+  // parse end of the round
+  demoFile.gameEvents.on("round_end", e => {
+    if(roundOn == true) {
+      roundOn = false;
       var t = demoFile.currentTime;
-      roundLatestStart = t;
-      // log round start
-      Logger.log(`round ${roundIndex} started ${secondsToTimestamp(t, demoGameStart, streamGameStart)}`);
-  
-      Logger.debug(t);
-    });
-  
-    // parse end of the round
-    demoFile.gameEvents.on("round_end", e => {
-      if(roundOn == true){
-        roundOn = false;
-        var t = demoFile.currentTime;
-        var round = new Round(roundLatestStart, t, roundEvents);
-        rounds.push(round);
-        // set the demo file game start to start time of round 1
-        demoGameStart = demoGameStart == null? roundLatestStart : demoGameStart;
-        // generate highlights for the round
-        round.sortKeyEvents();
-        round.calculateEventRates();
-        round.getHighRateTimes();
-        round.mergeTimeRanges();
-        round.getKills();
-        Logger.log(round.getStreamTimestamps(demoGameStart, streamGameStart));
-        // write highlights to output page
-        outputPage.addRoundHighlights(round.highlights, demoGameStart, streamGameStart, roundIndex);
-        outputPage.writeToFile("output.html");
-        // reset roundEvents 
-        roundEvents = [];
-        // log round end
-        Logger.log(`round ${roundIndex} ended ${secondsToTimestamp(t, demoGameStart, streamGameStart)}`);
+      var round = new Round(roundLatestStart, t, roundEvents);
+      rounds.push(round);
+      // set the demo file game start to start time of round 1
+      demoGameStart = demoGameStart == null? roundLatestStart : demoGameStart;
+      // generate highlights for the round
+      round.sortKeyEvents();
+      round.calculateEventRates();
+      round.getHighRateTimes();
+      round.mergeTimeRanges();
+      round.getKills();
+      const { timestamps, timestampsAsSeconds } = round.getStreamTimestamps(demoGameStart, streamGameStart);
+      Logger.log(timestamps);
+      // add highlights as seconds to array
+      allHighlights.push(timestampsAsSeconds);
+      // write highlights to output page
+      outputPage.addRoundHighlights(round.highlights, demoGameStart, streamGameStart, roundIndex);
+      outputPage.writeToFile("output.html");
+      // reset roundEvents 
+      roundEvents = [];
+      // log round end
+      Logger.log(`round ${roundIndex} ended ${secondsToTimestamp(t, demoGameStart, streamGameStart)}`);
 
-        Logger.debug(round.plotAllEvents());
-        Logger.debug('');
-        Logger.debug(round.plotHighRates());
-        Logger.debug('');
-        Logger.debug(round.plotHighlightTimes());
-        Logger.debug('');
-        // round.getKills();
-        Logger.debug(`set demoGameStart to: ${demoGameStart}`);
+      Logger.debug(round.plotAllEvents());
+      Logger.debug('');
+      Logger.debug(round.plotHighRates());
+      Logger.debug('');
+      Logger.debug(round.plotHighlightTimes());
+      Logger.debug('');
+      // round.getKills();
+      Logger.debug(`set demoGameStart to: ${demoGameStart}`);
 
-        roundIndex++;
-      }
-    });
-  
-    demoFile.gameEvents.on("player_death", e => {
-      var t = demoFile.currentTime - 20;
-      const attacker = demoFile.entities.getByUserId(e.attacker);
-      const attackerName = attacker ? attacker.name : "unnamed";
+      roundIndex++;
+    }
+  });
 
-      if(roundOn == true){
-        deathEvent = { time: t, type: "player_death", attacker_name: attackerName};
-        roundEvents.push(deathEvent);
-      }
-      
-      const victim = demoFile.entities.getByUserId(e.userid);
-      const victimName = victim ? victim.name : "unnamed";
-      const headshotText = e.headshot ? " HS" : "";
-      Logger.debug(`${attackerName} [${e.weapon}${headshotText}] ${victimName} -> ${secondsToTimestamp(t, demoGameStart, streamGameStart)}`);
+  demoFile.on("end", e => {
+    if (e) {
+      Logger.log(e);
+    }
+    Logger.log("Demofile parsing complete.");
+    Logger.debug(allHighlights);
 
+    fs.writeFile("./timestamps.json", JSON.stringify(allHighlights), (err) => {
+      if (err) {
+          Logger.log(err);
+          return;
+      };
+      Logger.log("Timestamps have been written to file");
     });
-  
-    // parse bomb_defuses
-    demoFile.gameEvents.on("bomb_defused", e => {
-      var t = demoFile.currentTime - 20;
-      if(roundOn == true){
-        bombDefuseEvent = { time: demoFile.currentTime, type: "bomb_defused" };
-        roundEvents.push(bombDefuseEvent);
-      }
-      Logger.debug(`Bomb defused -> ${secondsToTimestamp(t, demoGameStart, streamGameStart)}`);
-    });
-  
-    // parse bomb_planted
-    demoFile.gameEvents.on("bomb_planted", e => {
-      var t = demoFile.currentTime - 20;
-      if (roundOn == true) {
-        bombPlantEvent = { time: demoFile.currentTime, type: "bomb_planted" };
-        roundEvents.push(bombPlantEvent);
-      }
-      Logger.debug(`Bomb planted -> ${secondsToTimestamp(t, demoGameStart, streamGameStart)}`);
-    });
-  
-    demoFile.parse(buffer);
-  });  
+  });
+
+  demoFile.gameEvents.on("player_death", e => {
+    var t = demoFile.currentTime - 20;
+    const attacker = demoFile.entities.getByUserId(e.attacker);
+    const attackerName = attacker ? attacker.name : "unnamed";
+
+    if(roundOn == true){
+      deathEvent = { time: t, type: "player_death", attacker_name: attackerName};
+      roundEvents.push(deathEvent);
+    }
+    
+    const victim = demoFile.entities.getByUserId(e.userid);
+    const victimName = victim ? victim.name : "unnamed";
+    const headshotText = e.headshot ? " HS" : "";
+    Logger.debug(`${attackerName} [${e.weapon}${headshotText}] ${victimName} -> ${secondsToTimestamp(t, demoGameStart, streamGameStart)}`);
+
+  });
+
+  // parse bomb_defuses
+  demoFile.gameEvents.on("bomb_defused", e => {
+    var t = demoFile.currentTime - 20;
+    if(roundOn == true){
+      bombDefuseEvent = { time: demoFile.currentTime, type: "bomb_defused" };
+      roundEvents.push(bombDefuseEvent);
+    }
+    Logger.debug(`Bomb defused -> ${secondsToTimestamp(t, demoGameStart, streamGameStart)}`);
+  });
+
+  // parse bomb_planted
+  demoFile.gameEvents.on("bomb_planted", e => {
+    var t = demoFile.currentTime - 20;
+    if (roundOn == true) {
+      bombPlantEvent = { time: demoFile.currentTime, type: "bomb_planted" };
+      roundEvents.push(bombPlantEvent);
+    }
+    Logger.debug(`Bomb planted -> ${secondsToTimestamp(t, demoGameStart, streamGameStart)}`);
+  });
+
+  demoFile.parse(buffer);
 }
 
 module.exports = parseDemo;

--- a/video-output/generate_video.py
+++ b/video-output/generate_video.py
@@ -1,10 +1,12 @@
 from moviepy.editor import *
 import json
 
+pathToFullVideo = "/Users/tylerlam/Downloads/CSGO - Liquid vs. mousesports [Cache] Map 1 - GRAND FINAL - ESL One New York 2018.mp4"
+
 with open("../demofile-parsing/timestamps.json", "r") as read_file:
     data = json.load(read_file)
 
-fullvideo = VideoFileClip("/Users/tylerlam/Downloads/CSGO - Liquid vs. mousesports [Cache] Map 1 - GRAND FINAL - ESL One New York 2018.mp4")
+fullvideo = VideoFileClip(pathToFullVideo)
 
 clips = []
 roundNumber = 1

--- a/video-output/generate_video.py
+++ b/video-output/generate_video.py
@@ -1,0 +1,21 @@
+from moviepy.editor import *
+import json
+
+with open("../demofile-parsing/timestamps.json", "r") as read_file:
+    data = json.load(read_file)
+
+fullvideo = VideoFileClip("/Users/tylerlam/Downloads/CSGO - Liquid vs. mousesports [Cache] Map 1 - GRAND FINAL - ESL One New York 2018.mp4")
+
+clips = []
+roundNumber = 1
+for round in data:
+  transition = TextClip("Round {}".format(roundNumber), font='Arial', fontsize=70, color="white", size=fullvideo.size)
+  roundNumber += 1
+  clips.append(transition.set_duration(3))
+  for highlight in round:
+    start_time = highlight[0]
+    end_time = highlight[1]
+    clips.append(fullvideo.subclip(start_time, end_time))
+
+final_video = concatenate_videoclips(clips)
+final_video.write_videofile("highlights.mp4", codec='libx264', audio_codec='aac', temp_audiofile='temp-audio.m4a', remove_temp=True)


### PR DESCRIPTION
The parse_demo.js file changes look kinda fcked because I changed the indents. I didn't actually change the functionality that much. All I did was write the timestamps to an `allHighlights` array, then write those to a json file after parsing is finished.

How to run it: 

1.  You'll need a few packages installed for the video splicing to work first: 
https://zulko.github.io/moviepy/ 
http://www.besavvy.com/documentation/4-5/Editor/031350_installimgk.htm

I ran into some issues with the setup, so I suspect y'all will too. LMK and i'll try to help you through those (might be hard bc i'm on mac and you guys are PC) 

2. run parseDemo as usual (`npm start`)
3. Download the full version of the video
4. Edit `generate_video.py` to point to the full video path
3. cd to `/video-output` then run `python generate_video.py` 

