### PR TITLE
Get MFCCs as feature from Audio File

### DIFF
--- a/audio-analysis/main.py
+++ b/audio-analysis/main.py
@@ -35,21 +35,22 @@ def analyzeVideoSound(url, tag):
     video.getTextAnalysis()
     video.getAmplitudeAnalysis()
     video.getPitchAnalysis()
+    video.getMFCCAnalysis()
 
-    #    df1              df2                df4
-    # (time, word)   (time, amplitude)   (time, pitch)
-    #     |                |                  |
-    #     |                |                  |
-    #     V________________V                  |
-    #            |                            |
-    #            |                            |
-    #            V____________________________V
-    #           df3                |
-    #   (word, time, amplitude)    |
-    #                              |
-    #                              V
-    #                             df5
-    #                 (word, time, amplitude, pitch)
+    #    df1              df2                df4                |
+    # (time, word)   (time, amplitude)   (time, pitch)          |
+    #     |                |                  |                 |  
+    #     |                |                  |                 |
+    #     V________________V                  |                 |
+    #            |                            |                 |
+    #            |                            |                 |
+    #            V____________________________V                 |
+    #           df3                |                            |
+    #   (word, time, amplitude)    |                            |
+    #                              |                            |
+    #                              V                            V
+    #                             df5                           df6
+    #                 (word, time, amplitude, pitch)          (mfcc)
 
     df1 = pd.DataFrame(video.word_list)
     # We do not need two end_time_s_x and end_time_s_y columns :)
@@ -65,6 +66,8 @@ def analyzeVideoSound(url, tag):
     df5.to_csv("data_export.csv", header=True)
     #Export video breakdown to SQL
     df5.to_sql("test_table", con=engine, if_exists='append')
+    df6 = pd.DataFrame(video.mfcc_list)
+    print(df6)
 
 ##### Prompt for Highlight Video and Tagging #####
 def prompt():

--- a/audio-analysis/requirements.txt
+++ b/audio-analysis/requirements.txt
@@ -18,3 +18,4 @@ SpeechRecognition==3.8.1
 textblob==0.15.3
 youtube-dl==2020.1.15
 aubio==0.4.9
+librosa==0.7.2


### PR DESCRIPTION
What changed:

- Added the getMFCCAnalysis function to videoHelper.py

Note that 60 MFCC values are obtained for each second of a video. Also the MFCC DataFrame is not being sent to SQL yet.

This is an intermediate PR - in the next one we'll consolidate Amplitude/Pitch/MFCC for better runtime. Will also send the MFCC DataFrame to SQL.

**TO TEST:**
- cd `audio-analysis`
- make sure you have your secrets.py
- turn on _localhost_
- run `python main.py log`