### PR TITLE
Mfcc to database

### DIFF
--- a/audio-analysis/lib/etl/sqlConnection.py
+++ b/audio-analysis/lib/etl/sqlConnection.py
@@ -33,19 +33,36 @@ def getEngine(isTest):
 
 #SQL Connection Setup - Checks if table exists and if URL to be input already exists
 def sqlConnectionSetup(engine):
-    table_exists = False #Variable to check if table exists
-    # Create a metadata instance
-    meta = MetaData(engine)
-    #meta.reflect(bind=engine)
+    table_exists = False # Variable to check if table exists
+    meta = MetaData(engine) # Create a metadata instance
+    tables = ['test_table', 'mfcc_table']
+    
+    for _t in tables:
+        if tableExists(_t, meta) == False:
+            print('Table "', _t,'" does not exist. Creating..')
+            createTable(_t, meta, engine)
+    
+    meta.create_all() # Create all tables
 
+#Function checks if url exists in table already
+def urlExists(url, engine):
+    # Check if URL already exists
+    result = engine.execute('SELECT * FROM `test_table` WHERE `url`="' + url + '"')
+    print("Number of rows in database for this video", result.rowcount)
+
+    # If URL does exist return True
+    return result.rowcount > 0
+
+def tableExists(table_name, meta):
     # Check if table already exists
     for _t in meta.tables:
-        if _t == 'test_table': return
+        if _t == table_name: return True
+    return False
 
-    # If table doesn't exist, create it
-    if table_exists == False:
-        # Declare a table
-        table = Table('test_table',meta,
+def createTable(table_name, meta, engine):
+    #Creates the Test Table
+    if table_name == 'test_table':
+        test_table = Table(table_name,meta,
                     Column('id',Integer, primary_key=True, autoincrement=True),
                     Column('index',Integer),
                     Column('end_time_s',Integer),
@@ -60,17 +77,19 @@ def sqlConnectionSetup(engine):
                     Column('pitch',Float),
                     Column('p_confidence',Float),
                 )
-        # Create all tables
-        meta.create_all()
+    elif table_name == 'mfcc_test_table':
+        mfcc_table = Table(table_name,meta,
+                    Column('mfcc_id',Integer, primary_key=True, autoincrement=True),
+                    Column('index',Integer),
+                    Column('end_time_s',Integer),
+                    Column('start_time_s',Integer),
+                    Column('url',String(length=500)),
+                )
+        for i in range (1,60):
+            engine.execute('ALTER TABLE `'+ table_name +'` ADD mfcc_'+ '{0:0=2d}'.format(i) +' float;')
+    else:
+        print('ERROR: There is not setup for table "', table_name, '". Please create its setup.')
 
-#Function checks if url exists in table already
-def urlExists(url, engine):
-    # Check if URL already exists
-    result = engine.execute('SELECT * FROM `test_table` WHERE `url`="' + url + '"')
-    print("Number of rows in database for this video", result.rowcount)
-
-    # If URL does exist return True
-    return result.rowcount > 0
 
 def getTableAsDf(table_name):
     engine = getEngine(False)

--- a/audio-analysis/lib/utils/videoHelper.py
+++ b/audio-analysis/lib/utils/videoHelper.py
@@ -230,7 +230,7 @@ class videoObject:
                             }
                 
                 # MFCCs
-                mfccs = librosa.feature.mfcc(y=interval_audio_data, sr=fs, n_mfcc = 60)
+                mfccs = librosa.feature.mfcc(y=interval_audio_data, sr=fs, n_mfcc = 40)
                 mfccs_processed = np.mean(mfccs.T,axis=0)
                 mfcc_dict = {
                             'start_time_s': round(start_time),

--- a/audio-analysis/main.py
+++ b/audio-analysis/main.py
@@ -29,6 +29,7 @@ engine = getEngine(TESTING)
  
 def analyzeVideoSound(url, tag):
     global engine
+    global TESTING
     video = videoHelper.videoObject(url, tag, TESTING)
     print(video.getFilename())
     video.getAudio()
@@ -56,18 +57,21 @@ def analyzeVideoSound(url, tag):
     # We do not need two end_time_s_x and end_time_s_y columns :)
     df2 = pd.DataFrame(video.amplitude_list).drop(columns=['end_time_s'])
     join_condition = ['start_time_s', 'url']
-    print(df1)
-    print(df2)
     df3 = dfHelper.customLeftJoin(df1, df2, join_condition)
     df4 = pd.DataFrame(video.pitch_list).drop(columns=['end_time_s'])  
-    print(df4)
     df5 = pd.merge(df3, df4, how='left', on=join_condition)
-    #Export video breakdown to CSV
-    df5.to_csv("data_export.csv", header=True)
+    #df5.to_csv("data_export.csv", header=True) # Export video breakdown to CSV
     #Export video breakdown to SQL
     df5.to_sql("test_table", con=engine, if_exists='append')
     df6 = pd.DataFrame(video.mfcc_list)
-    print(df6)
+    #df6.to_csv("data_export_2.csv", header=True) # Export video breakdown to CSV
+    df6.to_sql("mfcc_table", con=engine, if_exists='append')
+    if TESTING:
+        print(df1)
+        print(df2)
+        print(df4)
+        print(df6)
+
 
 ##### Prompt for Highlight Video and Tagging #####
 def prompt():


### PR DESCRIPTION
Sends MFCC features to database in its own table (we will then join on start time)
Also changed from 60 to 40 MFCCs. I think it might be more accurate for 4 seconds intervals. We can play around with the values anyways.

**HOW TO TEST**
The usual:
- cd audio-analysis
- make sure you have secrets.py in the directory
- turn on your localhost
- run python main.py log
- should work same old, slightly faster for longer videos