### PR TITLE
Made 4 seconds Time Windows for audio features

### DIFF
--- a/audio-analysis/lib/etl/sqlConnection.py
+++ b/audio-analysis/lib/etl/sqlConnection.py
@@ -76,7 +76,7 @@ def createTable(table_name, meta, engine):
                     Column('amplitude_peak',Integer),
                     Column('pitch',Float),
                 )
-    elif table_name == 'mfcc_test_table':
+    elif table_name == 'mfcc_table':
         mfcc_table = Table(table_name,meta,
                     Column('mfcc_id',Integer, primary_key=True, autoincrement=True),
                     Column('index',Integer),

--- a/audio-analysis/lib/etl/sqlConnection.py
+++ b/audio-analysis/lib/etl/sqlConnection.py
@@ -75,7 +75,6 @@ def createTable(table_name, meta, engine):
                     Column('amplitude',Float),
                     Column('amplitude_peak',Integer),
                     Column('pitch',Float),
-                    Column('p_confidence',Float),
                 )
     elif table_name == 'mfcc_test_table':
         mfcc_table = Table(table_name,meta,

--- a/audio-analysis/secrets.py
+++ b/audio-analysis/secrets.py
@@ -1,2 +1,0 @@
-db_username = 'admin'
-db_password = 'password'

--- a/audio-analysis/secrets.py
+++ b/audio-analysis/secrets.py
@@ -1,0 +1,2 @@
+db_username = 'admin'
+db_password = 'password'


### PR DESCRIPTION
4 seconds time windows with 2 seconds overlap for each of the following:
- Pitch
- Amplitude
- MFCCs

Also did a bit of cleaning:
-Removed `p_confidence` as a feature
-Renamed MFCC table to not return weird error (see _sqlConnection.py_

**HOW TO TEST**
The usual:
- cd audio-analysis
- make sure you have secrets.py in the directory (password = _password_ locally)
- turn on your localhost
- run `python main.py log` choose option 3
- should work same old with 4 second intervals, 2 second overlaps